### PR TITLE
Added ability to choose a raspberry Pi platform as a make rule when compiling

### DIFF
--- a/Dockerfiles/Dockerfile-newer
+++ b/Dockerfiles/Dockerfile-newer
@@ -1,0 +1,48 @@
+# Dockerfile to be copied in the parent directory by the make tool.
+# This builds a 64bit image for Pi 3, Pi 3+, Pi 4, Pi 400, Pi Zero 2 W, Pi CM3, Pi CM3+, Pi CM4
+
+FROM ubuntu:20.04
+
+ENV LINUX_KERNEL_VERSION=5.15
+ENV LINUX_KERNEL_BRANCH=rpi-${LINUX_KERNEL_VERSION}.y
+
+ENV TZ=Europe/Copenhagen
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update
+RUN apt-get install -y git make gcc bison flex libssl-dev bc ncurses-dev kmod
+RUN apt-get install -y crossbuild-essential-arm64
+RUN apt-get install -y wget zip unzip fdisk nano curl xz-utils
+
+WORKDIR /rpi-kernel
+RUN git clone https://github.com/raspberrypi/linux.git -b ${LINUX_KERNEL_BRANCH} --depth=1
+WORKDIR /rpi-kernel/linux
+RUN export PATCH=$(curl -s https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/${LINUX_KERNEL_VERSION}/ | sed -n 's:.*<a href="\(.*\).patch.gz">.*:\1:p' | sort -V | tail -1) && \
+    echo "Downloading patch ${PATCH}" && \
+    curl https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/${LINUX_KERNEL_VERSION}/${PATCH}.patch.gz --output ${PATCH}.patch.gz && \
+    gzip -cd /rpi-kernel/linux/${PATCH}.patch.gz | patch -p1 --verbose
+
+ENV KERNEL=kernel8
+ENV ARCH=arm64
+ENV CROSS_COMPILE=aarch64-linux-gnu-
+
+RUN make bcm2711_defconfig
+RUN ./scripts/config --disable CONFIG_VIRTUALIZATION
+RUN ./scripts/config --enable CONFIG_PREEMPT_RT
+RUN ./scripts/config --disable CONFIG_RCU_EXPERT
+RUN ./scripts/config --enable CONFIG_RCU_BOOST
+RUN ./scripts/config --set-val CONFIG_RCU_BOOST_DELAY 500
+
+RUN make -j4 Image modules dtbs
+
+WORKDIR /raspios
+RUN apt -y install
+RUN export DATE=$(curl -s https://downloads.raspberrypi.org/raspios_lite_arm64/images/ | sed -n 's:.*raspios_lite_arm64-\(.*\)/</a>.*:\1:p' | tail -1) && \
+    export RASPIOS=$(curl -s https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-${DATE}/ | sed -n 's:.*<a href="\(.*\).xz">.*:\1:p' | tail -1) && \
+    echo "Downloading ${RASPIOS}.xz" && \
+    curl https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-${DATE}/${RASPIOS}.xz --output ${RASPIOS}.xz && \
+    xz -d ${RASPIOS}.xz
+
+RUN mkdir /raspios/mnt && mkdir /raspios/mnt/disk && mkdir /raspios/mnt/boot
+ADD build64.sh ./build.sh
+ADD config.txt ./

--- a/Dockerfiles/Dockerfile-older
+++ b/Dockerfiles/Dockerfile-older
@@ -1,3 +1,6 @@
+# Dockerfile to be copied in the parent directory by the make tool.
+# This builds a 32bit image for Pi 1, Pi Zero, Pi Zero W and Pi CM1
+
 FROM ubuntu:20.04
 
 ENV LINUX_KERNEL_VERSION=5.15
@@ -8,7 +11,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update
 RUN apt-get install -y git make gcc bison flex libssl-dev bc ncurses-dev kmod
-RUN apt-get install -y crossbuild-essential-arm64
+RUN apt-get install -y crossbuild-essential-armhf
 RUN apt-get install -y wget zip unzip fdisk nano curl xz-utils
 
 WORKDIR /rpi-kernel
@@ -19,27 +22,30 @@ RUN export PATCH=$(curl -s https://mirrors.edge.kernel.org/pub/linux/kernel/proj
     curl https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/${LINUX_KERNEL_VERSION}/${PATCH}.patch.gz --output ${PATCH}.patch.gz && \
     gzip -cd /rpi-kernel/linux/${PATCH}.patch.gz | patch -p1 --verbose
 
-ENV KERNEL=kernel8
-ENV ARCH=arm64
-ENV CROSS_COMPILE=aarch64-linux-gnu-
+ENV KERNEL=kernel
+ENV ARCH=arm
+ENV CROSS_COMPILE=arm-linux-gnueabihf-
 
-RUN make bcm2711_defconfig
+RUN make bcmrpi_defconfig
 RUN ./scripts/config --disable CONFIG_VIRTUALIZATION
 RUN ./scripts/config --enable CONFIG_PREEMPT_RT
 RUN ./scripts/config --disable CONFIG_RCU_EXPERT
 RUN ./scripts/config --enable CONFIG_RCU_BOOST
+RUN ./scripts/config --enable CONFIG_SMP
+RUN ./scripts/config --disable CONFIG_BROKEN_ON_SMP
 RUN ./scripts/config --set-val CONFIG_RCU_BOOST_DELAY 500
 
-RUN make Image modules dtbs
+RUN make -j4 zImage modules dtbs
 
 WORKDIR /raspios
 RUN apt -y install
-RUN export DATE=$(curl -s https://downloads.raspberrypi.org/raspios_lite_arm64/images/ | sed -n 's:.*raspios_lite_arm64-\(.*\)/</a>.*:\1:p' | tail -1) && \
-    export RASPIOS=$(curl -s https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-${DATE}/ | sed -n 's:.*<a href="\(.*\).xz">.*:\1:p' | tail -1) && \
+#TODO Change links
+RUN export DATE=$(curl -s https://downloads.raspberrypi.org/raspios_lite_armhf/images/ | sed -n 's:.*raspios_lite_armhf-\(.*\)/</a>.*:\1:p' | tail -1) && \
+    export RASPIOS=$(curl -s https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-${DATE}/ | sed -n 's:.*<a href="\(.*\).xz">.*:\1:p' | tail -1) && \
     echo "Downloading ${RASPIOS}.xz" && \
-    curl https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-${DATE}/${RASPIOS}.xz --output ${RASPIOS}.xz && \
+    curl https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-${DATE}/${RASPIOS}.xz --output ${RASPIOS}.xz && \
     xz -d ${RASPIOS}.xz
 
 RUN mkdir /raspios/mnt && mkdir /raspios/mnt/disk && mkdir /raspios/mnt/boot
-ADD build.sh ./
+ADD build32.sh ./build.sh
 ADD config.txt ./

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
 .PHONY: all custom
 
 all: clean
+	cp Dockerfiles/Dockerfile-newer Dockerfile
+	$(MAKE) build
+
+Pi1 Pi2 PiZero PiCM1: clean
+	cp Dockerfiles/Dockerfile-older Dockerfile
+	$(MAKE) build
+
+Pi3 Pi4 Pi400 PiZero2 PiCM3 PiCM4: clean
+	cp Dockerfiles/Dockerfile-newer Dockerfile
+	$(MAKE) build
+
+build:
 	mkdir -p build
 	docker build -t rpi-rt-linux .
 	docker rm tmp-rpi-rt-linux || true
@@ -13,3 +25,4 @@ custom:
 
 clean:
 	rm -fr build
+	rm Dockerfile || true

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Clone this repository and run `make`. It will create a folder `build` with a zip
 - linux kernel version 5.15 (you may change it inside `Dockerfile`)
 - the latest rt patch is downloaded from `https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/`
 - the latest raspbian image is downloaded from `https://downloads.raspberrypi.org/raspios_lite_arm64/images/`
-- building for pi3, pi4, pi400, piCM3, and piCM4 by default
+- building by default an image compatible with pi3, pi4, pi400, piCM3, and piCM4.
 
-you can run `make platform` where platform is either `Pi1`, `Pi2`, `PiZero`, `PiCM1`, `Pi3`, `Pi4i`, `Pi400`, `PiZero2`, `PiCM3`, or `PiCM4`.
+you can run `make platform` where `platform` is either `Pi1`, `Pi2`, `PiZero`, `PiCM1`, `Pi3`, `Pi4i`, `Pi400`, `PiZero2`, `PiCM3`, or `PiCM4`.
 
 ## How to burn the image to an SD card
 
@@ -55,6 +55,8 @@ policy: other/other: loadavg: 0.53 0.62 0.39 2/166 1463
 T: 0 ( 1463) P: 0 I:1000 C:  16114 Min:     11 Act:   42 Avg:   66 Max:     459
 ```
 which shows a maximum latency of `459us` (roughly half a millisecond). Values vary depending on CPU load.
+
+Please note that cyclictest does not put any load on the cpu, the results are useless if the test is not done while your RT application runs, or while an equivalent stress-test is running. You might want to read the cyclictest documentation [here](https://wiki.linuxfoundation.org/realtime/documentation/howto/tools/cyclictest/start) to learn how to build your tests.
 
 ## How to customize the kernel image
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ Please replace `/dev/sdcard` in the above example with the right location of you
 
 ## How to test if the RT patch was successfully applied
 
-Once you wrote the image to the SD card, place the card into the raspberry pi. Power the pi and ssh into it (ssh is enabled by default). Run `uname -a` and it should print `PREEMPT_RT` indicating that the RT patch is applied to the kernel:
+Once you wrote the image to the SD card, place the card into the raspberry pi. Power the pi and ssh into it (ssh is enabled by default). Run `uname -a` and it should print `SMP` and `PREEMPT_RT`, indicating that the RT patch is applied to the kernel:
 ```
 pi@raspberrypi:~ $ uname -a
 Linux raspberrypi 5.10.95-rt61-rc1-v8+ #1 SMP PREEMPT_RT Mon Mar 28 13:28:11 CEST 2022 aarch64 GNU/Linux
 ```
+For Raspberry Pi processors that have only 1 core, such as the Pi Zero W, The SMP flag (Symetrical multiprocessing) is deactivated because it needs at least 2 cores to work.
 
 You may benchmark the real-time capabilities of the pi by running `rt-tests`. Install `rt-tests`:
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ make menuconfig
 
 ## Known issues:
 - Having multiple Dockerfiles and build.sh for each platform is not ideal, there should be a cleaner way to do it.
-- There is an USB issue on the Raspberry Pi Zero 2 that requires disabling USB FIQ support with the following options added to /boot/cmdline.txt. This will slightly reduce the USB performance, but USB devices will still work without crashing the kernel.
+- There is an USB issue on the Raspberry Pi Zero 2 that requires disabling USB FIQ support with the following options added to /boot/cmdline.txt. This will slightly reduce the USB performance, but USB devices will still work without crashing the kernel. FIQ is an ARM feature meaning (Fast Interrupt Request) disabling it shouldn't prevent anything from working correctly, but it will increase the latency.
 ```
 dwc_otg.fiq_enable=0
 dwc_otg.fiq_fsm_enable=0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Clone this repository and run `make`. It will create a folder `build` with a zip
 - the latest raspbian image is downloaded from `https://downloads.raspberrypi.org/raspios_lite_arm64/images/`
 - building by default an image compatible with pi3, pi4, pi400, piCM3, and piCM4.
 
-you can run `make platform` where `platform` is either `Pi1`, `Pi2`, `PiZero`, `PiCM1`, `Pi3`, `Pi4i`, `Pi400`, `PiZero2`, `PiCM3`, or `PiCM4`.
+you can run `make [platform]` where `platform` is either `Pi1`, `Pi2`, `PiZero`, `PiCM1`, `Pi3`, `Pi4i`, `Pi400`, `PiZero2`, `PiCM3`, or `PiCM4`.
 
 ## How to burn the image to an SD card
 

--- a/README.md
+++ b/README.md
@@ -65,3 +65,12 @@ Run `make custom`. You will get a shell to a container. Then run:
 cd /rpi-rt-kernel/linux
 make menuconfig
 ```
+
+## Known issues:
+- Having multiple Dockerfiles and build.sh for each platform is not ideal, there should be a cleaner way to do it.
+- There is an USB issue on the Raspberry Pi Zero 2 that requires disabling USB FIQ support with the following options added to /boot/cmdline.txt. This will slightly reduce the USB performance, but USB devices will still work without crashing the kernel.
+```
+dwc_otg.fiq_enable=0
+dwc_otg.fiq_fsm_enable=0
+```
+More on this issue [here](https://wiki.linuxfoundation.org/realtime/documentation/known_limitations) and [here](https://www.osadl.org/Single-View.111+M5c03315dc57.0.html)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Clone this repository and run `make`. It will create a folder `build` with a zip
 - linux kernel version 5.15 (you may change it inside `Dockerfile`)
 - the latest rt patch is downloaded from `https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/`
 - the latest raspbian image is downloaded from `https://downloads.raspberrypi.org/raspios_lite_arm64/images/`
+- building for pi3, pi4, pi400, piCM3, and piCM4 by default
+
+you can run `make platform` where platform is either `Pi1`, `Pi2`, `PiZero`, `PiCM1`, `Pi3`, `Pi4i`, `Pi400`, `PiZero2`, `PiCM3`, or `PiCM4`.
 
 ## How to burn the image to an SD card
 

--- a/build32.sh
+++ b/build32.sh
@@ -10,10 +10,10 @@ make INSTALL_MOD_PATH=/raspios/mnt/disk modules_install
 make INSTALL_DTBS_PATH=/raspios/mnt/boot dtbs_install
 cd -
 
-cp /rpi-kernel/linux/arch/arm64/boot/Image /raspios/mnt/boot/$KERNEL\_rt.img
-cp /rpi-kernel/linux/arch/arm64/boot/dts/broadcom/*.dtb /raspios/mnt/boot/
-cp /rpi-kernel/linux/arch/arm64/boot/dts/overlays/*.dtb* /raspios/mnt/boot/overlays/
-cp /rpi-kernel/linux/arch/arm64/boot/dts/overlays/README /raspios/mnt/boot/overlays/
+cp /rpi-kernel/linux/arch/arm/boot/dts/*.dtb /raspios/mnt/boot/
+cp /rpi-kernel/linux/arch/arm/boot/dts/overlays/*.dtb* /raspios/mnt/boot/overlays/
+cp /rpi-kernel/linux/arch/arm/boot/dts/overlays/README /raspios/mnt/boot/overlays/
+cp /rpi-kernel/linux/arch/arm/boot/zImage /raspios/mnt/boot/$KERNEL\_rt.img
 
 cp /raspios/config.txt /raspios/mnt/boot/
 touch /raspios/mnt/boot/ssh

--- a/build64.sh
+++ b/build64.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+RASPIOS=$(ls *.img -1 | sed -e 's/\.img$//')
+
+mount -t ext4 -o loop,offset=$((532480*512)) ${RASPIOS}.img /raspios/mnt/disk
+mount -t vfat -o loop,offset=$((8192*512)),sizelimit=$((524288*512)) ${RASPIOS}.img /raspios/mnt/boot
+
+cd /rpi-kernel/linux/
+make INSTALL_MOD_PATH=/raspios/mnt/disk modules_install
+make INSTALL_DTBS_PATH=/raspios/mnt/boot dtbs_install
+cd -
+
+cp /rpi-kernel/linux/arch/arm64/boot/dts/broadcom/*.dtb /raspios/mnt/boot/
+cp /rpi-kernel/linux/arch/arm64/boot/dts/overlays/*.dtb* /raspios/mnt/boot/overlays/
+cp /rpi-kernel/linux/arch/arm64/boot/dts/overlays/README /raspios/mnt/boot/overlays/
+cp /rpi-kernel/linux/arch/arm64/boot/Image /raspios/mnt/boot/$KERNEL\_rt.img
+
+cp /raspios/config.txt /raspios/mnt/boot/
+touch /raspios/mnt/boot/ssh
+
+umount /raspios/mnt/disk
+umount /raspios/mnt/boot
+
+mkdir build
+zip build/${RASPIOS}.zip ${RASPIOS}.img

--- a/config.txt
+++ b/config.txt
@@ -1,8 +1,39 @@
+[pi4]
+# Enable DRM VC4 V3D driver on top of the dispmanx display stack
+dtoverlay=vc4-fkms-v3d
+max_framebuffers=2
+
 # For more options and information see
 # http://rpf.io/configtxt
 # Some settings may impact device functionality. See link above for details
+
+[pi1]
+# Applies to Model 1A, Model 1B, Model 1A+, Model 1B+, Compute Module 1
+kernel=kernel_rt.img
+arm_64bit=0
+[pi2]
+# Applies to Model 2B (BCM2836- or BCM2837-based)
+kernel=kernel_rt.img
+arm_64bit=0
+[pi0]
+# Applies to Zero, Zero W, Zero 2 W
+kernel=kernel_rt.img
+arm_64bit=0
+
+[pi4]
+# Applies to Model 4B, Pi 400, Compute Module 4
 kernel=kernel8_rt.img
 arm_64bit=1
+[pi3]
+# Applies to Model 3B, Model 3B+, Model 3A+, Compute Module 3, Compute Module 3+
+kernel=kernel8_rt.img
+arm_64bit=1
+[pi02]
+# Applies to Zero 2 W
+kernel=kernel8_rt.img
+arm_64bit=1
+
+[all]
 enable_uart=1
 force_turbo=1
 
@@ -62,11 +93,5 @@ dtoverlay=i2c-rtc,ds1307
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
-[pi4]
-# Enable DRM VC4 V3D driver on top of the dispmanx display stack
-dtoverlay=vc4-fkms-v3d
-max_framebuffers=2
-
-[all]
 #dtoverlay=vc4-fkms-v3d
 dtoverlay=pwm,pin=12,func=4


### PR DESCRIPTION
Now builds both 32 bit and 64 bits versions of RT linux for any specified Raspberry Pi platform.
Successfully tested on Pi 4B, Pi ZeroW, Pi Zero2W. See changes to README for more details.

PS: Thank you, even though we had to make a few changes, it was a great help to us.