### PR TITLE
Fix shell conditional square brackets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,13 +42,13 @@ ENV RASPIOS_IMAGE_NAME=${RASPIOS_IMAGE_NAME:-raspios_lite_arm64}
 # print the above env variables
 RUN echo ${KERNEL} ${ARCH} ${CROSS_COMPILE} ${RASPIOS_IMAGE_NAME}
 
-RUN [[ "$ARCH" = "arm" ]] && make bcmrpi_defconfig || make bcm2711_defconfig
+RUN [ "$ARCH" = "arm" ] && make bcmrpi_defconfig || make bcm2711_defconfig
 RUN ./scripts/config --disable CONFIG_VIRTUALIZATION
 RUN ./scripts/config --enable CONFIG_PREEMPT_RT
 RUN ./scripts/config --disable CONFIG_RCU_EXPERT
 RUN ./scripts/config --enable CONFIG_RCU_BOOST
-RUN [[ "$ARCH" = "arm" ]] && ./scripts/config --enable CONFIG_SMP || true
-RUN [[ "$ARCH" = "arm" ]] && ./scripts/config --disable CONFIG_BROKEN_ON_SMP || true
+RUN [ "$ARCH" = "arm" ] && ./scripts/config --enable CONFIG_SMP || true
+RUN [ "$ARCH" = "arm" ] && ./scripts/config --disable CONFIG_BROKEN_ON_SMP || true
 RUN ./scripts/config --set-val CONFIG_RCU_BOOST_DELAY 500
 
 RUN make -j4 Image modules dtbs

--- a/build.sh
+++ b/build.sh
@@ -10,12 +10,12 @@ make INSTALL_MOD_PATH=/raspios/mnt/disk modules_install
 make INSTALL_DTBS_PATH=/raspios/mnt/boot dtbs_install
 cd -
 
-if [ "$ARCH" == "arm64" ]; then
+if [ "$ARCH" = "arm64" ]; then
     cp /rpi-kernel/linux/arch/arm64/boot/dts/broadcom/*.dtb /raspios/mnt/boot/
     cp /rpi-kernel/linux/arch/arm64/boot/dts/overlays/*.dtb* /raspios/mnt/boot/overlays/
     cp /rpi-kernel/linux/arch/arm64/boot/dts/overlays/README /raspios/mnt/boot/overlays/
     cp /rpi-kernel/linux/arch/arm64/boot/Image /raspios/mnt/boot/$KERNEL\_rt.img
-elif [ $ARCH == "arm" ]; then
+elif [ "$ARCH" = "arm" ]; then
     cp /rpi-kernel/linux/arch/arm/boot/dts/*.dtb /raspios/mnt/boot/
     cp /rpi-kernel/linux/arch/arm/boot/dts/overlays/*.dtb* /raspios/mnt/boot/overlays/
     cp /rpi-kernel/linux/arch/arm/boot/dts/overlays/README /raspios/mnt/boot/overlays/


### PR DESCRIPTION
Fix for incorrect use of square bracket conditionals. Single brackets should be used when using simple equality (=) on strings.