### PR TITLE
Fixes for some filepath errors with 32-bit builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN [ "$ARCH" = "arm" ] && ./scripts/config --enable CONFIG_SMP || true
 RUN [ "$ARCH" = "arm" ] && ./scripts/config --disable CONFIG_BROKEN_ON_SMP || true
 RUN ./scripts/config --set-val CONFIG_RCU_BOOST_DELAY 500
 
-RUN make -j4 Image modules dtbs
+RUN make -j4 Image zImage modules dtbs
 
 RUN echo "using raspberry pi image ${RASPIOS_IMAGE_NAME}"
 WORKDIR /raspios

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ if [ "$ARCH" = "arm64" ]; then
     cp /rpi-kernel/linux/arch/arm64/boot/dts/overlays/README /raspios/mnt/boot/overlays/
     cp /rpi-kernel/linux/arch/arm64/boot/Image /raspios/mnt/boot/$KERNEL\_rt.img
 elif [ "$ARCH" = "arm" ]; then
-    cp /rpi-kernel/linux/arch/arm/boot/dts/*.dtb /raspios/mnt/boot/
+    cp /rpi-kernel/linux/arch/arm/boot/dts/broadcom/*.dtb /raspios/mnt/boot/
     cp /rpi-kernel/linux/arch/arm/boot/dts/overlays/*.dtb* /raspios/mnt/boot/overlays/
     cp /rpi-kernel/linux/arch/arm/boot/dts/overlays/README /raspios/mnt/boot/overlays/
     cp /rpi-kernel/linux/arch/arm/boot/zImage /raspios/mnt/boot/$KERNEL\_rt.img


### PR DESCRIPTION
I'm trying to build a kernel-rt for a PiZero and I ran into the same errors mentioned in #16 and #14. These two changes seem to allow the build to complete and result in a valid image. 

From the [docs](https://www.raspberrypi.com/documentation/computers/linux_kernel.html):
> Next, build the kernel. This step can take a long time, depending on your Raspberry Pi model.
> * Run the following commands to build a 64-bit kernel:
> ``` make -j6 Image.gz modules dtbs ```
> * Run the following command to build a 32-bit kernel:
> ``` make -j6 zImage modules dtbs ```

> 2. Depending on your [kernel version](https://www.raspberrypi.com/documentation/computers/linux_kernel.html#identify-your-kernel-version), run the following command:
> * For kernels up to version 6.4:
> ``` sudo cp arch/arm/boot/dts/*.dtb /boot/firmware/ ```
> * For kernels version 6.5 and above:
> ``` sudo cp arch/arm/boot/dts/broadcom/*.dtb /boot/firmware/ ```
