### PR TITLE
Only select .img.xz file from RaspiOS file list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN echo "using raspberry pi image ${RASPIOS}"
 WORKDIR /raspios
 
 RUN export DATE=$(curl -s https://downloads.raspberrypi.org/${RASPIOS}/images/ | sed -n "s:.*${RASPIOS}-\(.*\)/</a>.*:\1:p" | tail -1) && \
-    export RASPIOS_IMAGE_NAME=$(curl -s https://downloads.raspberrypi.org/${RASPIOS}/images/${RASPIOS}-${DATE}/ | sed -n "s:.*<a href=\"\(.*\).xz\">.*:\1:p" | tail -1) && \
+    export RASPIOS_IMAGE_NAME=$(curl -s https://downloads.raspberrypi.org/${RASPIOS}/images/${RASPIOS}-${DATE}/ | sed -n "s:.*<a href=\"\(.*img\).xz\">.*:\1:p" | tail -1) && \
     echo "Downloading ${RASPIOS_IMAGE_NAME}.xz" && \
     curl https://downloads.raspberrypi.org/${RASPIOS}/images/${RASPIOS}-${DATE}/${RASPIOS_IMAGE_NAME}.xz --output ${RASPIOS}.xz && \
     xz -d ${RASPIOS}.xz


### PR DESCRIPTION
With the list of files for the latest RaspiOS release, the script automatically selected the .sbom.xz file instead of the .img.xz file. This results in the following error for me at the end of the build process:

```
docker run --privileged --name tmp-rpi-rt-linux rpi-rt-linux /raspios/build.sh
sfdisk: raspios_lite_arm64: does not contain a recognized partition table
/raspios/build.sh: 8: arithmetic expression: expecting primary: "*512"
make[1]: *** [Makefile:59: build] Error 2
make[1]: Leaving directory '/home/max/rpi-rt-kernel'
make: *** [Makefile:8: PiCM4] Error 2
```

With the fix, the correct file is downloaded and the build succeeds.